### PR TITLE
Fixes for current Hearthstone patch level

### DIFF
--- a/decompiler.cs
+++ b/decompiler.cs
@@ -468,7 +468,7 @@ class SilentOrbitTypeProcessor : TypeProcessor {
 					fieldType = FieldType.Bytes;
 					break;
 				default:
-					Console.WriteLine("unresolved type");
+					Console.WriteLine("unresolved type for field '" + name + "' in " + result.Name.Text);
 					break;
 				}
 			} else if (info.Method.DeclaringType.Name == "BinaryWriter") {
@@ -494,7 +494,7 @@ class SilentOrbitTypeProcessor : TypeProcessor {
 				}
 			}
 			if (fieldType == FieldType.Invalid) {
-				Console.WriteLine("unresolved type");
+				Console.WriteLine("unresolved type for field '" + name + "' in " + result.Name.Text);
 			}
 
 			var field = new FieldNode(name, label, fieldType, tag);

--- a/decompiler.cs
+++ b/decompiler.cs
@@ -10,16 +10,33 @@ using System.IO;
 
 class ProtobufDecompiler {
 	public void ProcessTypes(IEnumerable<TypeDefinition> types) {
+		// A map from type name to its file
+		var typesMap = new Dictionary<string, string>();
+		var currAssembly = Assembly.GetExecutingAssembly();
+		var typesMapName = currAssembly.GetManifestResourceNames()[0];
+		using (var typesMapFile = currAssembly.GetManifestResourceStream(typesMapName))
+		using (var typesMapReader = new StreamReader(typesMapFile)) {
+			while (!typesMapReader.EndOfStream) {
+				var line = typesMapReader.ReadLine().Trim();
+				if (line.Length == 0) continue;
+				if (line[0] == '#') continue;
+				var parts = line.Split(new[] { "\t" }, StringSplitOptions.RemoveEmptyEntries);
+				typesMap[parts[1]] = parts[0];
+			}
+		}
+
+		// Find proto type
 		if (types.Any(x => x.Name == "IProtoBuf" || x.Name == "ServiceDescriptor")) {
 			Console.WriteLine("detected SilentOrbit protos");
-			processor = new SilentOrbitTypeProcessor();
+			processor = new SilentOrbitTypeProcessor(typesMap);
 		} else {
 			// We could detect based on subclassing GeneratedMessage*, but no
 			// point unless we have more than 2 types of protogens.
 			Console.WriteLine("assuming Google protos");
-			processor = new GoogleTypeProcessor();
+			processor = new GoogleTypeProcessor(typesMap);
 		}
 
+		// Process types
 		foreach (var type in types) {
 			processor.Process(type);
 		}
@@ -54,52 +71,6 @@ class ProtobufDecompiler {
 			}
 		}
 
-		// Move extensions to their sources:
-		var blacklistedExtensionSources = new[]{
-			// These types aren't allowed to have extensions, because they were
-			// made by an intern or something:
-			".PegasusShared.ScenarioDbRecord"
-		};
-		foreach (var nodeList in processor.PackageNodes.Values) {
-			var messages = nodeList
-				.Where(x => x is MessageNode)
-				.Select(x => x as MessageNode)
-				.Where(x => !blacklistedExtensionSources.Contains(x.Name.Text));
-			foreach (var message in messages) {
-				var extensions = message.Fields
-					.Where(x => x.Label != FieldLabel.Required &&
-						x.Tag >= 100 &&
-						!blacklistedExtensionSources.Contains(x.TypeName.Text))
-					.ToList();
-				foreach (var extField in extensions) {
-					message.Fields.Remove(extField);
-					message.AcceptsExtensions = true;
-					var target = message.Name;
-					var source = extField.TypeName;
-					if (String.IsNullOrEmpty(source.Package)) {
-						throw new Exception("extension field is not a message");
-					}
-					var sourceNode = allMessages[source.Text];
-					sourceNode.AddExtend(target, extField);
-				}
-			}
-		}
-
-		// A map from type name to its file
-		var typesMap = new Dictionary<string, string>();
-		var currAssembly = Assembly.GetExecutingAssembly();
-		var typesMapName = currAssembly.GetManifestResourceNames()[0];
-		using (var typesMapFile = currAssembly.GetManifestResourceStream(typesMapName))
-		using (var typesMapReader = new StreamReader(typesMapFile)) {
-			while (!typesMapReader.EndOfStream) {
-				var line = typesMapReader.ReadLine().Trim();
-				if (line.Length == 0) continue;
-				if (line[0] == '#') continue;
-				var parts = line.Split(new[]{"\t"}, StringSplitOptions.RemoveEmptyEntries);
-				typesMap[parts[1]] = parts[0];
-			}
-		}
-
 		foreach (var nodeList in processor.PackageNodes.Values) {
 			string fileName = null;
 			FileNode fileNode = null;
@@ -127,11 +98,47 @@ class ProtobufDecompiler {
 		}
 
 		// Define "method_id" extension for identifying RPC methods.
-		var methodIdExtension = new ExtendNode(new TypeName(
-			"google.protobuf", "MethodOptions"));
+		/* var methodIdExtension = new ExtendNode(new TypeName(
+			"google.protobuf", "MethodOptions"), "");
 		methodIdExtension.Fields.Add(new FieldNode(
-			"method_id", FieldLabel.Optional, FieldType.UInt32, 50000));
-		fileNodes["bnet/rpc"].Types.Add(methodIdExtension);
+			"method_id", FieldLabel.Optional, FieldType.UInt32, 50000, ""));
+		fileNodes["bnet/rpc"].Types.Add(methodIdExtension); */
+
+		// Move extensions to their sources:
+		var blacklistedExtensionSources = new[]{
+			// These types aren't allowed to have extensions, because they
+			// will create circular references
+			".PegasusShared.ScenarioDbRecord",
+			".PegasusShared.DeckRulesetDbRecord",
+			".PegasusShared.SubsetCardListDbRecord",
+
+			// These types aren't allowed because they use record numbers >100 but not as extensions
+			".PegasusShared.TavernBrawlSpec"
+		};
+		foreach (var nodeList in processor.PackageNodes.Values) {
+			var messages = nodeList
+				.Where(x => x is MessageNode)
+				.Select(x => x as MessageNode)
+				.Where(x => !blacklistedExtensionSources.Contains(x.Name.Text));
+			foreach (var message in messages) {
+				var extensions = message.Fields
+					.Where(x => x.Label != FieldLabel.Required &&
+						x.Tag >= 100 &&
+						!blacklistedExtensionSources.Contains(x.TypeName.Text))
+					.ToList();
+				foreach (var extField in extensions) {
+					message.Fields.Remove(extField);
+					message.AcceptsExtensions = true;
+					var target = message.Name;
+					var source = extField.TypeName;
+					if (String.IsNullOrEmpty(source.Package)) {
+						throw new Exception("extension field is not a message");
+					}
+					var sourceNode = allMessages[source.Text];
+					sourceNode.AddExtend(target, extField, messageFile[target.Text]);
+				}
+			}
+		}
 	}
 
 	// map from filename to filenode
@@ -254,14 +261,17 @@ class ProtobufDecompiler {
 // Represents a type capable of processing c# types generated by protoc and
 // decompiling them into protobuf type nodes.
 abstract class TypeProcessor {
+	protected Dictionary<string, string> typesMap;
+
 	public abstract void Process(TypeDefinition type);
 
 	public abstract void Complete();
 
 	public Dictionary<string, List<ILanguageNode>> PackageNodes { get; set; }
 
-	public TypeProcessor() {
+	public TypeProcessor(Dictionary<string, string> typesMap) {
 		PackageNodes = new Dictionary<string, List<ILanguageNode>>();
+		this.typesMap = typesMap;
 	}
 
 	protected void AddPackageNode(string package, ILanguageNode node) {
@@ -275,6 +285,8 @@ abstract class TypeProcessor {
 // Processes protobuf types generated by SilentOrbit's protobuf implementation,
 // found at <https://github.com/hultqvist/ProtoBuf>
 class SilentOrbitTypeProcessor : TypeProcessor {
+	public SilentOrbitTypeProcessor(Dictionary<string, string> typesMap) : base(typesMap) { }
+
 	public override void Process(TypeDefinition type) {
 		// Since a protobuf package corresponds to a C# namespaces, no generated
 		// protobuf classes exist in the root namespace.
@@ -496,14 +508,16 @@ class SilentOrbitTypeProcessor : TypeProcessor {
 			if (fieldType == FieldType.Invalid) {
 				Console.WriteLine("unresolved type for field '" + name + "' in " + result.Name.Text);
 			}
-
-			var field = new FieldNode(name, label, fieldType, tag);
-			field.TypeName = subType;
-			field.Packed = packed;
-			if (defaults.ContainsKey(name)) {
-				field.DefaultValue = defaults[name];
+			else {
+				var field = new FieldNode(name, label, fieldType, tag,
+					(subType.Name != null && typesMap.ContainsKey(subType.OuterType.Text) ? typesMap[subType.OuterType.Text] : ""));
+				field.TypeName = subType;
+				field.Packed = packed;
+				if (defaults.ContainsKey(name)) {
+					field.DefaultValue = defaults[name];
+				}
+				result.Fields.Add(field);
 			}
-			result.Fields.Add(field);
 		};
 		serializeWalker.Walk();
 
@@ -574,6 +588,8 @@ class SilentOrbitTypeProcessor : TypeProcessor {
 // Processes protobuf types generated by the protobuf-csharp-port project,
 // which is currently owned by Google and was originally created by Jon Skeet.
 class GoogleTypeProcessor : TypeProcessor {
+	public GoogleTypeProcessor(Dictionary<string, string> typesMap) : base(typesMap) { }
+
 	public override void Process(TypeDefinition type) {
 		return;
 	}

--- a/extractor.cs
+++ b/extractor.cs
@@ -47,7 +47,7 @@ static class Extractor {
 		decompiler.ProcessTypes(allTypes);
 		decompiler.WriteProtos(extractDir);
 		if (goDir != null) {
-			decompiler.WriteGoProtos(goDir, "github.com/HearthSim/hs-proto/go/");
+			decompiler.WriteGoProtos(goDir, "github.com/HearthSim/hs-proto-go/");
 		}
 	}
 }

--- a/protobuf.cs
+++ b/protobuf.cs
@@ -227,9 +227,9 @@ public class MessageNode : ILanguageNode, IImportUser {
 		Extends = new Dictionary<TypeName, ExtendNode>();
 	}
 
-	public void AddExtend(TypeName target, FieldNode field) {
+	public void AddExtend(TypeName target, FieldNode field, string fileMapping) {
 		if (!Extends.ContainsKey(target))
-			Extends[target] = new ExtendNode(target);
+			Extends[target] = new ExtendNode(target, fileMapping);
 		Extends[target].Fields.Add(field);
 	}
 }
@@ -275,7 +275,10 @@ public class EnumNode : ILanguageNode {
 public class ExtendNode : ILanguageNode, IImportUser {
 	public string Text {
 		get {
-			var result = String.Format("extend {0} {{\n", Target.Text);
+			var result = String.Format("extend {0} {{\n", (
+				FileMapping.Length > 0 ? FileMapping.Substring(FileMapping.IndexOf("/") + 1) + "."
+				+ Target.Text.Substring(("." + Target.Text).LastIndexOf(".")) : Target.Text)
+			);
 			foreach (var field in Fields)
 				result += "\t" + field.Text;
 			result += "}\n";
@@ -303,10 +306,12 @@ public class ExtendNode : ILanguageNode, IImportUser {
 
 	public TypeName Target;
 	public List<FieldNode> Fields;
+	public string FileMapping;
 
-	public ExtendNode(TypeName target) {
+	public ExtendNode(TypeName target, string fileMapping) {
 		Target = target;
 		Fields = new List<FieldNode>();
+		FileMapping = fileMapping;
 	}
 }
 
@@ -337,7 +342,13 @@ public class FieldNode : ILanguageNode {
 			var label = Enum.GetName(typeof(FieldLabel), Label).ToLower();
 			var type = Enum.GetName(typeof(FieldType), Type).ToLower();
 			if (Type == FieldType.Message || Type == FieldType.Enum) {
-				type = TypeName.Text;
+
+				if (FileMapping.Length > 0 && TypeName.Text.Contains(".")) {
+					type = FileMapping.Substring(FileMapping.IndexOf("/") + 1) + "."
+							+ TypeName.Text.Substring(("." + TypeName.Text).LastIndexOf("."));
+				} else {
+					type = TypeName.Text;
+				}
 			}
 			var result = String.Format("{0} {1} {2} = {3}",
 				label, type, Name, Tag);
@@ -362,6 +373,7 @@ public class FieldNode : ILanguageNode {
 	public FieldType Type;
 	public string Name;
 	public int Tag;
+	public string FileMapping;
 	// used when Type is Enum or Message
 	public TypeName TypeName;
 	// [default = this], shown if not null
@@ -369,11 +381,12 @@ public class FieldNode : ILanguageNode {
 	// shown if not false
 	public bool Packed;
 
-	public FieldNode(string name, FieldLabel label, FieldType type, int tag) {
+	public FieldNode(string name, FieldLabel label, FieldType type, int tag, string fileMapping) {
 		Label = label;
 		Type = type;
 		Name = name;
 		Tag = tag;
+		FileMapping = fileMapping;
 	}
 }
 

--- a/protobuf.cs
+++ b/protobuf.cs
@@ -78,6 +78,9 @@ public struct TypeName : ILanguageNode {
 	}
 	public TypeName OuterType {
 		get {
+			if (Name == null)
+				return this;
+
 			var i = Name.IndexOf('.');
 			return i < 0 ? this : new TypeName(Package, Name.Substring(0, i));
 		}

--- a/types
+++ b/types
@@ -52,6 +52,6 @@ bnet/resource_service			.bnet.protocol.resources.Resources
 pegasus/patching				.WTCG.BI.DataOnlyPatching
 pegasus/bobnet					.BobNetProto.PACKETTYPES
 pegasus/game					.PegasusGame.Tag
-pegasus/shared					.PegasusShared.CardDef
+pegasus/shared					.PegasusShared.DatabaseDeckCard
 pegasus/util					.PegasusUtil.ClientOption
 pegasus/spectator				.SpectatorProto.JoinInfo


### PR DESCRIPTION
Fix first .PegasusShared package is now DatabaseDeckCard in types
Fix incorrect directory path in auto-generated import statements when outputting Go-friendly proto files
Remove google.protobuf references (for now) to avoid protoc-gen-go looking for non-existent files
Use type-to-file mappings when outputting field and extension names if referencing constructs in a different .proto file

TODO: Circular import references