### PR TITLE
Force types file to be specified as a command line option

### DIFF
--- a/decompiler.cs
+++ b/decompiler.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 using System.IO;
 
 class ProtobufDecompiler {
-	public void ProcessTypes(IEnumerable<TypeDefinition> types) {
+	public void ProcessTypes(IEnumerable<TypeDefinition> types, string typesMapFile) {
 		if (types.Any(x => x.Name == "IProtoBuf" || x.Name == "ServiceDescriptor")) {
 			Console.WriteLine("detected SilentOrbit protos");
 			processor = new SilentOrbitTypeProcessor();
@@ -87,9 +87,6 @@ class ProtobufDecompiler {
 
 		// A map from type name to its file
 		var typesMap = new Dictionary<string, string>();
-		var currAssembly = Assembly.GetExecutingAssembly();
-		var typesMapName = currAssembly.GetManifestResourceNames()[0];
-		using (var typesMapFile = currAssembly.GetManifestResourceStream(typesMapName))
 		using (var typesMapReader = new StreamReader(typesMapFile)) {
 			while (!typesMapReader.EndOfStream) {
 				var line = typesMapReader.ReadLine().Trim();

--- a/extractor.cs
+++ b/extractor.cs
@@ -5,13 +5,15 @@ using Mono.Cecil.Rocks;
 
 static class Extractor {
 	static void Main(string[] args) {
-		if (args.Length == 0) {
-			Console.Write("Hearthstone Protobuf Extractor --- ");
-			Console.WriteLine("Usage: proto-extractor [options] [input dlls...]");
+		if (args.Length < 2) {
+			Console.WriteLine("Hearthstone Protobuf Extractor --- ");
+			Console.WriteLine("Usage: proto-extractor [options] [types file] [input dlls...]");
 			Console.WriteLine("    --output, -o  Directory where .proto files are written");
+			Console.WriteLine("    --go-out, -g  Directory where Go-friendly .proto files are written");
 			return;
 		}
 
+		var typesFile = "";
 		var extractDir = ".";
 		string goDir = null;
 		var assemblies = new List<string>();
@@ -34,8 +36,21 @@ static class Extractor {
 					}
 				}
 			} else {
-				assemblies.Add(arg);
+				if (typesFile.Length == 0)
+					typesFile = arg;
+				else
+					assemblies.Add(arg);
 			}
+		}
+
+		if (typesFile == "") {
+			Console.WriteLine("No types file specified");
+			return;
+		}
+
+		if (assemblies.Count == 0) {
+			Console.WriteLine("No DLL files specified");
+			return;
 		}
 
 		var allTypes = new List<TypeDefinition>();
@@ -44,7 +59,7 @@ static class Extractor {
 		}
 
 		var decompiler = new ProtobufDecompiler();
-		decompiler.ProcessTypes(allTypes);
+		decompiler.ProcessTypes(allTypes, typesFile);
 		decompiler.WriteProtos(extractDir);
 		if (goDir != null) {
 			decompiler.WriteGoProtos(goDir, "github.com/HearthSim/hs-proto-go/");

--- a/proto-extractor.csproj
+++ b/proto-extractor.csproj
@@ -47,6 +47,8 @@
     <Compile Include="decompiler.cs" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="types" />
+    <Content Include="types">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Types file is no longer an embedded resource
Command line options are checked for type and DLL files