### PR TITLE
Changes to extension behaviour

### DIFF
--- a/decompiler.cs
+++ b/decompiler.cs
@@ -74,13 +74,20 @@ class ProtobufDecompiler {
 				foreach (var extField in extensions) {
 					message.Fields.Remove(extField);
 					message.AcceptsExtensions = true;
+					message.ExtendLowerBound = Math.Min(message.ExtendLowerBound, extField.Tag);
+					message.ExtendUpperBound = Math.Max(message.ExtendUpperBound, extField.Tag);
+
 					var target = message.Name;
 					var source = extField.TypeName;
+					// Extensions which are primitive types
 					if (String.IsNullOrEmpty(source.Package)) {
-						throw new Exception("extension field is not a message");
+						message.AddExtend(target, extField);
 					}
-					var sourceNode = allMessages[source.Text];
-					sourceNode.AddExtend(target, extField);
+					// Extensions which are messages in other files
+					else {
+						var sourceNode = allMessages[source.Text];
+						sourceNode.AddExtend(target, extField);
+					}
 				}
 			}
 		}

--- a/protobuf.cs
+++ b/protobuf.cs
@@ -174,7 +174,9 @@ public class MessageNode : ILanguageNode, IImportUser {
 					if (line.Trim().Length != 0)
 						result += "\t" + line + "\n";
 			if (AcceptsExtensions)
-				result += "\textensions " + ExtendLowerBound + " to " + ExtendUpperBound + ";\n";
+				result += "\textensions "
+					+ (FieldUpperBound < 100? 100 : ExtendLowerBound) + " to "
+					+ (FieldUpperBound > ExtendUpperBound? ExtendUpperBound : 10000) + ";\n";
 
 			return result + "}\n";
 		}
@@ -220,6 +222,12 @@ public class MessageNode : ILanguageNode, IImportUser {
 	public bool AcceptsExtensions;
 	public int ExtendLowerBound;
 	public int ExtendUpperBound;
+
+	public int FieldUpperBound {
+		get {
+			return Fields.Max(x => x.Tag);
+		}
+	}
 
 	public MessageNode(TypeName name) {
 		Name = name;

--- a/protobuf.cs
+++ b/protobuf.cs
@@ -174,7 +174,7 @@ public class MessageNode : ILanguageNode, IImportUser {
 					if (line.Trim().Length != 0)
 						result += "\t" + line + "\n";
 			if (AcceptsExtensions)
-				result += "\textensions 100 to 10000;\n";
+				result += "\textensions " + ExtendLowerBound + " to " + ExtendUpperBound + ";\n";
 
 			return result + "}\n";
 		}
@@ -218,6 +218,8 @@ public class MessageNode : ILanguageNode, IImportUser {
 	public Dictionary<TypeName, ExtendNode> Extends;
 	public TypeName Name;
 	public bool AcceptsExtensions;
+	public int ExtendLowerBound;
+	public int ExtendUpperBound;
 
 	public MessageNode(TypeName name) {
 		Name = name;
@@ -225,6 +227,8 @@ public class MessageNode : ILanguageNode, IImportUser {
 		Messages = new List<MessageNode>();
 		Fields = new List<FieldNode>();
 		Extends = new Dictionary<TypeName, ExtendNode>();
+		ExtendLowerBound = int.MaxValue;
+		ExtendUpperBound = int.MinValue;
 	}
 
 	public void AddExtend(TypeName target, FieldNode field) {


### PR DESCRIPTION
- Track the minimum and maximum field IDs used as extension fields for each type
- Output 'extension X to Y' where X and Y are the minimum and maximum extension field IDs used for the type across all proto files

Not included in commit: remove PegasusShared.TavernBrawlSpec (introduced 4.3.12266) and DeckRulesetViolation (introduced 5.0.12574) from blacklistedExtensionSources.

2nd commit:
- Track field ID upper bound for each type
- X becomes 100 if no normal fields with IDs higher than 99 are defined
- Y becomes 10000 if no normal fields with IDs higher than the highest extension field ID are defined

Tested with Stove and Hearthstone 5.0.12574.
